### PR TITLE
fix: skip re-export when content unchanged, avoid redundant backups

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -101,13 +101,23 @@ export class IBookExport implements IExport {
 		try {
 			const filePath = normalizePath(path.join(this.plugin.settings.output, `${fileName}.md`));
 			const isExist = await this.plugin.app.vault.adapter.exists(filePath);
-			if (this.plugin.settings.backupWhenExist && isExist) {
-				// backup file if file already exists
-				// issue: #44
-				const backupPath = normalizePath(path.join(this.plugin.settings.output, `${fileName}-bk-${Date.now()}.md`));
-				this.plugin.app.vault.adapter.rename(filePath, backupPath);
+			if (isExist) {
+				// skip if content is identical, avoid redundant backups (issue: #44, #69)
+				const oldContent = await this.plugin.app.vault.adapter.read(filePath);
+				if (oldContent === content) {
+					return;
+				}
+				if (this.plugin.settings.backupWhenExist) {
+					// backup file if file already exists
+					// issue: #44
+					const backupPath = normalizePath(path.join(this.plugin.settings.output, `${fileName}-bk-${Date.now()}.md`));
+					await this.plugin.app.vault.adapter.rename(filePath, backupPath);
+				} else {
+					// remove old file so create() below can overwrite it
+					await this.plugin.app.vault.adapter.remove(filePath);
+				}
 			}
-			this.plugin.app.vault.create(
+			await this.plugin.app.vault.create(
 				path.join(this.plugin.settings.output, `${fileName}.md`),
 				content
 			);

--- a/src/export.ts
+++ b/src/export.ts
@@ -2,7 +2,7 @@ import { Annotation } from "@/types";
 import { getAllBookId, getBookById, getAnnotationBookId } from "@/api/ibook";
 import { IbookPluginSettings } from "@/config";
 import { Renderer } from "@/renderer";
-import { htmlToMarkdown, normalizePath } from "obsidian";
+import { TFile, htmlToMarkdown, normalizePath } from "obsidian";
 
 import IbookPlugin from "@/plugin";
 import * as path from "path";
@@ -68,7 +68,7 @@ export class IBookExport implements IExport {
 			);
 		}
 		const content = this.renderer.render(renderData);
-		this.save(renderData.library.ZTITLE, content);
+		await this.save(renderData.library.ZTITLE, content);
 	}
 
 	async getRenderDataById(bookId: string) {
@@ -100,10 +100,10 @@ export class IBookExport implements IExport {
 			.replace(/(\r\n|\n|\r|\/|\\\\)/gm, "-")
 		try {
 			const filePath = normalizePath(path.join(this.plugin.settings.output, `${fileName}.md`));
-			const isExist = await this.plugin.app.vault.adapter.exists(filePath);
-			if (isExist) {
+			const existing = this.plugin.app.vault.getAbstractFileByPath(filePath);
+			if (existing instanceof TFile) {
 				// skip if content is identical, avoid redundant backups (issue: #44, #69)
-				const oldContent = await this.plugin.app.vault.adapter.read(filePath);
+				const oldContent = await this.plugin.app.vault.read(existing);
 				if (oldContent === content) {
 					return;
 				}
@@ -111,16 +111,15 @@ export class IBookExport implements IExport {
 					// backup file if file already exists
 					// issue: #44
 					const backupPath = normalizePath(path.join(this.plugin.settings.output, `${fileName}-bk-${Date.now()}.md`));
-					await this.plugin.app.vault.adapter.rename(filePath, backupPath);
+					await this.plugin.app.vault.rename(existing, backupPath);
+					await this.plugin.app.vault.create(filePath, content);
 				} else {
-					// remove old file so create() below can overwrite it
-					await this.plugin.app.vault.adapter.remove(filePath);
+					// overwrite in place so the existing file is never left missing
+					await this.plugin.app.vault.modify(existing, content);
 				}
+				return;
 			}
-			await this.plugin.app.vault.create(
-				path.join(this.plugin.settings.output, `${fileName}.md`),
-				content
-			);
+			await this.plugin.app.vault.create(filePath, content);
 		} catch (error) {
 			if (!error.message.contains("file already exists")) {
 				throw error;

--- a/src/ui/search.ts
+++ b/src/ui/search.ts
@@ -48,9 +48,9 @@ export class IBookSearchModal extends IbookFuzzySuggestModal {
 		this.setPlaceholder("Search by book's title or author");
 	}
 
-	onChooseItem(item: LibraryAsset, evt: MouseEvent | KeyboardEvent): void {
+	async onChooseItem(item: LibraryAsset, evt: MouseEvent | KeyboardEvent): Promise<void> {
 		if (evt instanceof MouseEvent || evt.key == "Enter") {
-			this.plugin.export.generate(item.ZASSETID);
+			await this.plugin.export.generate(item.ZASSETID);
 			new Notice(
 				`Exporting Book: 《${item.ZTITLE}》 to ${this.plugin.settings.output}`
 			);


### PR DESCRIPTION
## Summary

Currently every full export (`cmd + p` → `ibook export`) re-creates **every** book file. When the `backupWhenExist` setting is enabled, each run renames the existing file to a `-bk-{timestamp}.md` copy — **even when the content is identical**. After a major update or repeated exports, this causes backup files to pile up indefinitely.

There is also a related bug: when `backupWhenExist` is **disabled**, an existing file is never updated at all — `vault.create()` throws `file already exists`, which is silently swallowed by the catch, so the old file stays forever.

## Changes (`src/export.ts` — `save()`)

1. If the target file exists, **read its content first**:
   - Content unchanged → skip entirely (no backup, no rewrite).
   - Content changed + `backupWhenExist` on → rename old file to `-bk-{timestamp}.md`, then write the new one (backup only happens on real changes).
   - Content changed + `backupWhenExist` off → remove old file, then write the new one, so overwriting actually works.

2. `await` the `rename` / `create` calls so operations are properly sequenced.

## Effect

- No more `-bk-*.md` pile-up on repeated full exports.
- Disabling backups now behaves as "overwrite" instead of "never update".

## Test

- `npm run build` (tsc + esbuild) passes.
- `npm run lint` passes (0 errors; pre-existing warnings in `src/typings` only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary file updates when exported content is unchanged.
  * Improved replacement handling by preserving timestamped backups or removing outdated files before saving.
  * Ensured file creation completes reliably before the operation finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->